### PR TITLE
V0.0.1

### DIFF
--- a/Classification/Base.py
+++ b/Classification/Base.py
@@ -26,8 +26,8 @@ class GTorchBase:
             self.config.train_dir = train_dir
             self.config.valid_dir = valid_dir
             self.config.test_dir = test_dir
-            if self.config.train_dir is not None:
-                self.config.classes = len([_dir for _dir in os.listdir(self.config.train_dir) if os.path.isdir(os.path.join(self.config.train_dir, _dir))])
+        if self.config.train_dir is not None:
+            self.config.classes = len([_dir for _dir in os.listdir(self.config.train_dir) if os.path.isdir(os.path.join(self.config.train_dir, _dir))])
 
         self.model: Optional[Any] = Utils.get_model(self.config)
         self.is_run: bool = False if model is None else True

--- a/Classification/Base.py
+++ b/Classification/Base.py
@@ -8,7 +8,7 @@ from .. import Errors
 
 
 class GTorchBase:
-    def __init__(self, model: Optional[str], train_dir: Optional[str], valid_dir: Optional[str], test_dir: Optional[str]):
+    def __init__(self, model: Optional[str], train_dir: str, valid_dir: str, test_dir: str):
         """
         - v0.0 -
         モデルと設定の定義だけ実行する。
@@ -22,11 +22,11 @@ class GTorchBase:
 
         self.config: Optional[Config] = Utils.get_config(model)
 
+        self.config.train_dir = train_dir
+        self.config.valid_dir = valid_dir
+        self.config.test_dir = test_dir
+
         if self.config is not None:
-            self.config.train_dir = train_dir
-            self.config.valid_dir = valid_dir
-            self.config.test_dir = test_dir
-        if self.config is not None and self.config.train_dir is not None:
             self.config.classes = len([_dir for _dir in os.listdir(self.config.train_dir) if os.path.isdir(os.path.join(self.config.train_dir, _dir))])
 
         self.model: Optional[Any] = Utils.get_model(self.config)
@@ -57,7 +57,12 @@ class GTorchBase:
 
 
 class GTorch(GTorchBase):
-    def __init__(self, model: Optional[str] = None, train_dir: Optional[str] = None, valid_dir: Optional[str] = None, test_dir: Optional[str] = None):
+    def __init__(self,
+                 model:     Optional[str] = None,
+                 train_dir: str           = 'dataset/train',
+                 valid_dir: str           = 'dataset/valid',
+                 test_dir:  str           = 'dataset/test'):
+
         super().__init__(model, train_dir, valid_dir, test_dir)
 
     def __call__(self):

--- a/Classification/Base.py
+++ b/Classification/Base.py
@@ -26,7 +26,7 @@ class GTorchBase:
             self.config.train_dir = train_dir
             self.config.valid_dir = valid_dir
             self.config.test_dir = test_dir
-        if self.config.train_dir is not None:
+        if self.config is not None and self.config.train_dir is not None:
             self.config.classes = len([_dir for _dir in os.listdir(self.config.train_dir) if os.path.isdir(os.path.join(self.config.train_dir, _dir))])
 
         self.model: Optional[Any] = Utils.get_model(self.config)

--- a/Classification/Trainer.py
+++ b/Classification/Trainer.py
@@ -22,7 +22,6 @@ class Trainer:
         self.config:        Config           = config
         self.transform:     Compose          = Utils.get_transform(config)
         self.data:          TrainData        = TrainData()
-        self.es_counter:    int              = 0
         self.best_accuracy: float            = 0.0
         self.test_accuracy: float            = 0.0
         self.criterion:     CrossEntropyLoss = CrossEntropyLoss()
@@ -57,7 +56,7 @@ class Trainer:
                 self.refresh_best(best_name)  # 訓練・バリデーションの結果からベストスコアを更新
                 self.write_log(log, epoch)    # ログ出力
 
-                if self.es_counter == self.config.early_stop:
+                if self.data.early_stop == self.config.early_stop:
                     print('Early Stop!!')
                     break
 

--- a/Classification/Trainer.py
+++ b/Classification/Trainer.py
@@ -33,7 +33,6 @@ class Trainer:
         self.valid_loader:  DataLoader       = self.get_dataloader(self.valid_dataset)
 
         self.model.to(self.config.device)
-
         os.makedirs(self.config.save_dir, exist_ok=False)
 
     def train(self):

--- a/Classification/Utils.py
+++ b/Classification/Utils.py
@@ -146,7 +146,7 @@ def get_transform(config: Config) -> Compose:
     return transform
 
 
-def get_image(transform: Compose, image: Union[str, np.ndarray, Image], device: torch.device) -> ImageFile:
+def get_image(transform: Compose, image: Union[str, np.ndarray, Image.Image], device: torch.device) -> ImageFile:
     if isinstance(image, str):
         image = Image.open(image)
     elif isinstance(image, np.ndarray):

--- a/Classification/Utils.py
+++ b/Classification/Utils.py
@@ -146,7 +146,7 @@ def get_transform(config: Config) -> Compose:
     return transform
 
 
-def get_image(transform: Compose, image: Union[str, np.ndarray, ImageFile], device: torch.device) -> ImageFile:
+def get_image(transform: Compose, image: Union[str, np.ndarray, Image], device: torch.device) -> ImageFile:
     if isinstance(image, str):
         image = Image.open(image)
     elif isinstance(image, np.ndarray):


### PR DESCRIPTION
### Window11での動作確認。
ResNet18のみ実行確認。
標準出力、model.pt、log.txt、config.pickleの出力確認。

**-OK-**
- [x] 訓練中の標準出力
- [x] 訓練時のCUDA使用
- [x] データセットのデフォルト値変更

**-NG-**
- [ ] model.ptの確認 => 推論機能実装次第確認必要。
- [ ] config.pickleの確認 => 推論機能実装次第確認必要。
- [ ] Mac以外での動作確認 => 画像分類タスクの実装が一通り終わってからテスト予定。

### CoPilot
This pull request includes several changes to the `Classification` module, focusing on improving code clarity and functionality. The most significant changes involve modifying constructor parameters, refactoring conditional checks, and updating type hints.

### Constructor Parameter Changes:
* [`Classification/Base.py`](diffhunk://#diff-56293370f67ed0fd7911f607ee388d86e0b26ff67fbd2a4db5774fddb08958a8L11-R11): Changed the `GTorchBase` constructor to require non-optional directory parameters (`train_dir`, `valid_dir`, `test_dir`).
* [`Classification/Base.py`](diffhunk://#diff-56293370f67ed0fd7911f607ee388d86e0b26ff67fbd2a4db5774fddb08958a8L60-R65): Updated the `GTorch` constructor to provide default directory paths.

### Refactoring Conditional Checks:
* [`Classification/Base.py`](diffhunk://#diff-56293370f67ed0fd7911f607ee388d86e0b26ff67fbd2a4db5774fddb08958a8L25-R29): Moved the `self.config` check to ensure directories are set before calculating classes.
* [`Classification/Trainer.py`](diffhunk://#diff-7346f61ecb1e0ce73a70b2de1fcdbbf7e39db243207b666d084516b65adf2b1aL60-R58): Replaced `self.es_counter` with `self.data.early_stop` in the early stopping condition.

### Type Hint Updates:
* [`Classification/Utils.py`](diffhunk://#diff-dfcae46ac397584fe521e8ae4b93d6fbf28894f3f8e3cf6b2a647d726904bbd7L149-R149): Updated the type hint for the `image` parameter in `get_image` from `ImageFile` to `Image.Image`.

### Code Cleanup:
* [`Classification/Trainer.py`](diffhunk://#diff-7346f61ecb1e0ce73a70b2de1fcdbbf7e39db243207b666d084516b65adf2b1aL25): Removed the unused `self.es_counter` variable from the `Trainer` class.
* [`Classification/Trainer.py`](diffhunk://#diff-7346f61ecb1e0ce73a70b2de1fcdbbf7e39db243207b666d084516b65adf2b1aL37): Removed an unnecessary blank line in the `Trainer` constructor.